### PR TITLE
Summary: Fixes #2 - convert readme to RST

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,2 +1,3 @@
-# ugetch
+ugetch
+======
 utf-8 getch, with support for arrows, tab, echoing, etc


### PR DESCRIPTION
**Problem:**
The README is in markdown, which is great, but is not parsed by pypi.
This means the project on pypi will not have a good readme displayed,
which is non-ideal.

**Analysis:**
Both pypi and github support parsing and displaying RST correctly, so
make the README an RST file.

**Testing:**
Manual testing via display on github.

**Documentation:**
This is a purely documentation commit.
