### PR TITLE
Summary:  fixes #4 - add travis badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
 ugetch
 ======
 utf-8 getch, with support for arrows, tab, echoing, etc
+
+.. image:: https://travis-ci.org/toejough/ugetch.svg
+   :target: https://travis-ci.org/toejough/ugetch


### PR DESCRIPTION
**Problem:**
No testing status badge.

**Analysis:**
While not really required, having a testing status badge lends a bit of confidence in the codebase.  Since this repo is using travis for testing, and travis supplies a badge, we should display it.

**Testing:**
Manual inspection of generated README page.

**Documentation:**
Addition of badge IS the documentation.
