### PR TITLE
Summary:  fixes #3 - add waffle badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,3 +4,7 @@ utf-8 getch, with support for arrows, tab, echoing, etc
 
 .. image:: https://travis-ci.org/toejough/ugetch.svg
    :target: https://travis-ci.org/toejough/ugetch
+   
+.. image:: https://badge.waffle.io/toejough/ugetch.svg?label=ready&title=Ready 
+ :target: https://waffle.io/toejough/ugetch 
+ :alt: 'Stories in Ready'


### PR DESCRIPTION
**Problem:**
No waffle badge.

**Analysis:**
The repo is using waffle.io for issue tracking, and they provide a badge.  It would be nice to provide some at-a-glance info about the project issue status.

**Testing:**
Manual inspection of generated README page.

**Documentation:**
The badge IS the documentation.
