### PR TITLE
Summary:  Fixes #5 - add ascii getch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python: 3.4
+install:
+- pip install tox
+script: tox

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,27 @@ utf-8 getch, with support for arrows, tab, echoing, etc
  :target: https://waffle.io/toejough/ugetch 
  :alt: 'Stories in Ready'
 
+* `api`_
 * `contribution`_
+
+API
+===
+
+* `getkey`_
+
+getkey
+------
+
+Gets a key from the ``infile`` and returns it to the user.  Currently supports returning ASCII chars.
+Any other keys entered (such as utf-8, arrow keys, etc) will result in returning individual bytes, one at a time.
+
+Parameters:
+
+* ``infile`` - defaults to the ``sys.stdin`` file, as it is set at call time.
+
+Returns:
+
+* ``key`` - a string value corresponding to the key read in from the TTY ('a', 'B', '-', etc).
 
 contribution
 ============

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+
+
+from setuptools import setup, find_packages
+
+
+setup(
+    name='ugetch',
+    version='0.1.0',
+    description='utf-8 getch, with tab, arrows, echo, etc',
+    long_description=open('README.rst').read(),
+    url='https://github.com/toejough/ugetch',
+    author='toejough',
+    author_email='toejough@gmail.com',
+    license='MIT',
+    classifiers=[
+            # How mature is this project? Common values are
+            #   3 - Alpha
+            #   4 - Beta
+            #   5 - Production/Stable
+            'Development Status :: 3 - Alpha',
+
+            # Indicate who your project is intended for
+            'Intended Audience :: Developers',
+
+            # Pick your license as you wish (should match "license" above)
+             'License :: OSI Approved :: MIT License',
+
+            # Specify the Python versions you support here. In particular, ensure
+            # that you indicate whether you support Python 2, Python 3 or both.
+            'Programming Language :: Python :: 2',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.4',
+    ],
+    keywords="getch utf8 utf-8 tab arrow",
+    packages=find_packages(),
+    install_requires=[],
+)

--- a/test_ugetch.py
+++ b/test_ugetch.py
@@ -1,0 +1,36 @@
+'''
+Test suite for ugetch
+'''
+
+
+# [ Imports ]
+# [ - Python ]
+import tempfile
+import os
+# [ - Third Party ]
+import pytest
+import pexpect
+# [ - Project ]
+import ugetch
+
+
+# [ Helpers ]
+def in_vs_out(input_values):
+    '''supply ascii chars, use getch, and validate ascii returned'''
+    p = pexpect.spawn("python ugetch-cli.py", timeout=0.5)
+    p.expect_exact("hit ctrl-c to exit.")
+    for value in input_values:
+        p.expect_exact("hit a key to print its representation: ")
+        p.sendline(value)
+        index = p.expect_exact([value, pexpect.EOF, pexpect.TIMEOUT])
+        assert index == 0, "did not find expected ({}) in output ({})".format(
+            value, p.before
+        )
+
+
+# [ Unit tests ]
+def test_getch_ascii():
+    '''supply ascii chars, use getch, and validate ascii returned'''
+    in_vs_out(" \n\t")
+    all_printable_acii = [chr(n) for n in range(32, 127)]  # not including 127
+    in_vs_out(all_printable_acii)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py34
+
+[testenv]
+commands = py.test -vx {posargs}
+deps =
+    pytest
+    pexpect
+    pytest-cache

--- a/ugetch-cli.py
+++ b/ugetch-cli.py
@@ -1,0 +1,24 @@
+'''
+Test script for ugetch
+'''
+
+
+# [ Imports ]
+# [ - Python ]
+import sys
+# [ - Third Party ]
+# [ - Project ]
+import ugetch
+
+
+# [ Test script ]
+if __name__ == "__main__":
+    print("hit ctrl-c to exit.")
+    try:
+        while True:
+            sys.stdout.write("hit a key to print its representation: ")
+            sys.stdout.flush()
+            print(ugetch.getkey())
+    except KeyboardInterrupt:
+        print("\nexiting due to Ctrl-c")
+        exit(0)

--- a/ugetch/__init__.py
+++ b/ugetch/__init__.py
@@ -1,0 +1,43 @@
+'''
+ugetch
+Supports getting ascii characters from the input
+'''
+
+
+# [ Imports ]
+# [ -Python ]
+import sys
+import termios
+
+
+# [ Global ]
+_DEFAULT=object()  # enable dynamic defaults
+
+
+# [ Helper Functions ]
+def _get_byte(infile):
+    fd = infile.fileno()
+    old_settings = termios.tcgetattr(fd)
+    byte = None
+    try:
+        new = termios.tcgetattr(fd)
+        new[3] = new[3] & ~termios.ECHO
+        new[3] = new[3] & ~termios.ICANON
+        termios.tcsetattr(fd, termios.TCSADRAIN, new)
+        byte = infile.read(1)
+    # no catching - don't know what could go wrong, so no good way to handle it right now.
+    # let it propagate up and generate a bug report.
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+    return byte
+
+
+# [ Core Functions ]
+def getkey(infile=_DEFAULT):
+    '''Get a single key from the input file'''
+    # Handle dynamic default
+    if infile == _DEFAULT:
+        # if not overridden, use the current sys.stdin
+        infile = sys.stdin
+    # Do the standard getch
+    return _get_byte(infile)


### PR DESCRIPTION
**Problem:**
getch isn't even implemented for ascii.

**Analysis:**
a basic ascii getch is required.  Add tests for it, add it, and document
it.
Add a travis config file to run the tests when a pull request is made.

**Testing:**
Added test_ugetch.py with a test for all printable ascii chars.

**Documentation:**
Updated README to add an API section with the new getkey function.
Updated internal docstrings to describe the function.
