### PR TITLE
Summary: Fixes #7 - tab support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
+# basic config
 language: python
 python: 3.4
 install:
 - pip install tox
 script: tox
+
+# whitelist
+branches:
+    only:
+        - master

--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,13 @@ API
 getkey
 ------
 
-Gets a "key" from the ``infile`` and returns it to the user, where "key" is a character or glyph.
-Currently supports parsing ASCII and UTF-8.
+Gets a "key" from the ``infile`` and returns it to the user, where "key" is a character, glyph, or string describing a control key.
+
+Currently supports parsing ASCII, UTF-8, and tab.
 Any other keys entered (such as arrow keys, UTF-16, etc) will result in returning individual bytes, one at a time.
+
+The tab key is represented as a string: 'TAB'.  This is not a "character", but it *is* a "key".  The implementation
+of keys may change in the future, but for now this seems to be simple and clear.
 
 Parameters:
 
@@ -34,7 +38,7 @@ Parameters:
 
 Returns:
 
-* ``key`` - a string value corresponding to the key read in from the TTY ('a', 'B', '-', etc).
+* ``key`` - a string value corresponding to the key read in from the TTY ('a', 'B', '-', '☢', 'TAB', etc).
 
 contribution
 ============

--- a/test_ugetch.py
+++ b/test_ugetch.py
@@ -19,8 +19,7 @@ import ugetch
 
 
 # [ Helpers ]
-def in_vs_out(input_values):
-    '''supply ascii chars, use getch, and validate ascii returned'''
+def start_cli_shim():
     # choose the correct spawn
     spawn = pexpect.spawn
     if sys.version_info.major == 3:
@@ -28,28 +27,51 @@ def in_vs_out(input_values):
     # spawn the subproc
     p = spawn("python ugetch-cli.py", timeout=0.5)
     p.expect_exact("hit ctrl-c to exit.")
+    return p
+
+
+def assert_expected(p, expected):
+    '''Assert that we get the expected value'''
+    index = p.expect_exact([expected, pexpect.EOF, pexpect.TIMEOUT])
+    assert index == 0, "did not find expected ({}) in output ({})".format(
+        value, p.before
+    )
+
+
+def in_vs_out(input_values):
+    '''supply ascii chars, use getch, and validate ascii returned'''
+    # get shim
+    p = start_cli_shim()
     # test each char
     for value in input_values:
         p.expect_exact("hit a key to print its representation: ")
         p.send(value)
-        index = p.expect_exact([value, pexpect.EOF, pexpect.TIMEOUT])
-        assert index == 0, "did not find expected ({}) in output ({})".format(
-            value, p.before
-        )
+        assert_expected(p, value)
 
 
 # [ Unit tests ]
 def test_getch_ascii():
     '''supply ascii chars, use getch, and validate ascii returned'''
-    in_vs_out(" \n\t")
     all_printable_acii = [chr(n) for n in range(32, 127)]  # not including 127
     in_vs_out(all_printable_acii)
+
 
 def test_getch_utf8():
     '''supply utf-8 glyphs, use getch, and validate the keys returned'''
     in_vs_out(['☢'])
     in_vs_out(['ά','έ','ή','ί','ΰ','α','β','γ','δ','ε','ζ','η','θ','ι','κ','λ','μ','ν','ξ','ο','π'])  # greek
     in_vs_out(['༰','༱','༲','༳','༴',' ༵','༶','༸',' ༹','༺',' ','༻',' ','༼','༽',' ༾',' ༿',' ','ཀ','ཁ','ག','གྷ','ང','ཅ','ཆ'])  # tibetan
+
+
+def test_getch_tab():
+    # get shim
+    p = start_cli_shim()
+    # test each char
+    p.expect_exact("hit a key to print its representation: ")
+    p.send('\t')
+    assert_expected(p, 'TAB')
+    p.sendcontrol('i')
+    assert_expected(p, 'TAB')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Problem:**
No support for catching tabs

**Analysis:**
Tab-completion is a common thing to do with low-level input CLI control.
We should enable it by allowing users to catch when the tab key is
pressed.

Return 'TAB' instead of a character.  This is generally a control, along
the same lines as 'enter', and arrow keys, home key, etc.  At least,
that's the use case being targeted.  Returning a whole string is
overloading the idea of a "key", but it's lighter-weight than returning
an object you have to parse for every key.

I might still implement things that way in the end (objects), but I'm
not going to until necessary.  Using a string is still unambiguous
enough, because other characters are single characters, rather than
strings, and even multi-char unicode "characters" are not going to
overlap with the strings being used ('TAB', 'UP', 'DOWN', etc).

**Testing:**
Added a test which uses the '\t' key, as well as the control-i combo.

**Documentation:**
Added description of return value for tab.
